### PR TITLE
🏷️ Add pod status host IP

### DIFF
--- a/api.go
+++ b/api.go
@@ -45,9 +45,14 @@ type SpecSummary struct {
 	NodeName string `json:"nodeName"`
 }
 
+type StatusSummary struct {
+	HostIP string `json:"hostIp"`
+}
+
 type PodSummary struct {
-	Metadata *ObjectMeta  `json:"metadata"`
-	Spec     *SpecSummary `json:"spec"`
+	Metadata *ObjectMeta    `json:"metadata"`
+	Spec     *SpecSummary   `json:"spec"`
+	Status   *StatusSummary `json:"status"`
 }
 
 type Object struct {
@@ -257,6 +262,9 @@ func (e *Entry) SourceSummary() *ResolutionSummary {
 			Spec: &SpecSummary{
 				NodeName: e.Source.Pod.Spec.NodeName,
 			},
+			Status: &StatusSummary{
+				HostIP: e.Source.Pod.Status.HostIP,
+			},
 		}
 	}
 
@@ -297,6 +305,9 @@ func (e *Entry) DestinationSummary() *ResolutionSummary {
 			},
 			Spec: &SpecSummary{
 				NodeName: e.Destination.Pod.Spec.NodeName,
+			},
+			Status: &StatusSummary{
+				HostIP: e.Destination.Pod.Status.HostIP,
 			},
 		}
 	}


### PR DESCRIPTION
**Why we need this change:**
Streaming list is about to show more `src/dst` fields (with KFL select boxes) - node name is already available in `src/dst`, node IP is needed as well.

See: https://github.com/kubeshark/front/issues/169#issuecomment-2079714072

**Issue:**
- https://github.com/kubeshark/front/issues/169