### PR TITLE
Add container ID to the OutputChannelItem

### DIFF
--- a/api.go
+++ b/api.go
@@ -97,7 +97,7 @@ type ConnectionInfo struct {
 	ServerPort     string
 	ServerCgroupID uint64
 	IsOutgoing     bool
-  IsKubeProbe    bool
+	IsKubeProbe    bool
 	ContainerId    string
 }
 


### PR DESCRIPTION
It is going to used by syscal events code:
https://github.com/kubeshark/worker/blob/3885c22d31619826dc5e6a0063ce949b40d15730/system_events.go#L70