### PR TITLE
Add hub storage health data

### DIFF
--- a/health.go
+++ b/health.go
@@ -38,19 +38,26 @@ type HealthWorkerLicenseData struct {
 	StartTime      int64 `json:"startTime"`
 }
 
+type HealthHubStorage struct {
+	DiskUsed      uint64 `json:"diskUsed"`
+	DiskAvailable uint64 `json:"diskAvailable"`
+	DiskLimit     uint64 `json:"diskLimit"`
+}
+
 type HealthHub struct {
-	Workers              []HealthHubWorker       `json:"workers"`
-	Nodes                []HealthHubNode         `json:"nodes"`
-	NodeName             string                  `json:"nodeName"`
-	ClusterID            string                  `json:"clusterID"`
-	Version              string                  `json:"version"`
-	Timestamp            string                  `json:"timestamp"`
-	CPUUsage             float64                 `json:"cpuUsage"`
-	MemoryUsage          float64                 `json:"memoryUsage"`
-	LastRestartReason    string                  `json:"lastRestartReason"`
-	LastRestartTimestamp string                  `json:"lastRestartTimestamp"`
-	Resources            v1.ResourceRequirements `json:"resources"`
-	Restarts             int                     `json:"restarts"`
+	Workers              []HealthHubWorker              `json:"workers"`
+	Nodes                []HealthHubNode                `json:"nodes"`
+	NodeName             string                         `json:"nodeName"`
+	ClusterID            string                         `json:"clusterID"`
+	Version              string                         `json:"version"`
+	Timestamp            string                         `json:"timestamp"`
+	CPUUsage             float64                        `json:"cpuUsage"`
+	MemoryUsage          float64                        `json:"memoryUsage"`
+	LastRestartReason    string                         `json:"lastRestartReason"`
+	LastRestartTimestamp string                         `json:"lastRestartTimestamp"`
+	Resources            v1.ResourceRequirements        `json:"resources"`
+	Restarts             int                            `json:"restarts"`
+	Storage              map[string]*HealthHubStorage   `json:"storage,omitempty"`
 }
 
 type HealthHubWorker struct {


### PR DESCRIPTION
Towards https://github.com/kubeshark/hub/issues/557

Used here: https://github.com/kubeshark/hub/pull/581

Results in 

```
  "storage": {
    "snapshots": {
      "diskUsed": 0,
      "diskAvailable": 200021139456,
      "diskLimit": 21474836480
    }
  }
```

as part of health/telemetry